### PR TITLE
Fix deleting all tags that belong to the post

### DIFF
--- a/app/Http/Controllers/Admin/TagController.php
+++ b/app/Http/Controllers/Admin/TagController.php
@@ -44,7 +44,7 @@ class TagController extends Controller
     public function destroy(Tag $tag)
     {
         foreach ($tag->posts as $post) {
-            $post->tags()->detach();
+            $post->tags()->detach($tag);
         }
 
         if (!$tag->posts()->count()) {


### PR DESCRIPTION
Passing the $tag we are going to detach only the tag that we are deleting, otherwise, we will remove all post's tags.